### PR TITLE
Switch to the directgory containing the 'static' subdirectory in each of 

### DIFF
--- a/slides/scripts/build_direct_crunch.sh
+++ b/slides/scripts/build_direct_crunch.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Switch to the directory with the 'static' subdir containing the slides
+cd $(git rev-parse --show-toplevel)/slides
+
 BIN=crunch_server
 MIR_RUN=$(which mir-run)
 

--- a/slides/scripts/build_direct_fs.sh
+++ b/slides/scripts/build_direct_fs.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Switch to the directory with the 'static' subdir containing the slides
+cd $(git rev-parse --show-toplevel)/slides
+
 BIN=kv_ro_server
 MIR_RUN=$(which mir-run)
 

--- a/slides/scripts/build_socket_crunch.sh
+++ b/slides/scripts/build_socket_crunch.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -ex
 
+# Switch to the directory with the 'static' subdir containing the slides
+cd $(git rev-parse --show-toplevel)/slides
+
 BIN=crunch_server
 MIR_RUN=$(which mir-run)
 

--- a/slides/scripts/build_socket_fs.sh
+++ b/slides/scripts/build_socket_fs.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Switch to the directory with the 'static' subdir containing the slides
+cd $(git rev-parse --show-toplevel)/slides
+
 BIN=kv_ro_server
 MIR_RUN=$(which mir-run)
 

--- a/slides/scripts/build_xen_crunch.sh
+++ b/slides/scripts/build_xen_crunch.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Switch to the directory with the 'static' subdir containing the slides
+cd $(git rev-parse --show-toplevel)/slides
+
 BIN=crunch_server
 MIR_RUN=$(which mir-run)
 

--- a/slides/scripts/build_xen_fs.sh
+++ b/slides/scripts/build_xen_fs.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -ex
 
+# Switch to the directory with the 'static' subdir containing the slides
+cd $(git rev-parse --show-toplevel)/slides
+
 BIN=kv_ro_server
 MIR_RUN=$(which mir-run)
 


### PR DESCRIPTION
Running the scripts from inside their directory fails, because 'static' is '../static'

Switch to the directgory containing the 'static' subdirectory in each of the example scripts. They should work when run from any working directory within the git checkout now.
